### PR TITLE
Switch to kotlin-logging-jvm library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,13 +21,14 @@ repositories {
 extra["springAiVersion"] = "1.0.0"
 
 val telegramBotsVersion = "9.0.0"
+val kotlinLoggingVersion = "7.0.12"
 
 dependencies {
     implementation("org.springframework.ai:spring-ai-starter-model-openai")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
 
-    implementation("io.github.microutils:kotlin-logging:3.0.5")
+    implementation("io.github.oshai:kotlin-logging-jvm:$kotlinLoggingVersion")
     implementation("org.telegram:telegrambots-springboot-longpolling-starter:$telegramBotsVersion")
     implementation("org.telegram:telegrambots-client:$telegramBotsVersion")
     implementation("org.telegram:telegrambots-extensions:$telegramBotsVersion")

--- a/src/main/kotlin/ru/devmark/openai/bot/TelegramBot.kt
+++ b/src/main/kotlin/ru/devmark/openai/bot/TelegramBot.kt
@@ -1,6 +1,6 @@
 package ru.devmark.openai.bot
 
-import mu.KLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.telegram.telegrambots.extensions.bots.commandbot.CommandLongPollingTelegramBot
@@ -11,6 +11,8 @@ import org.telegram.telegrambots.meta.api.objects.Update
 import org.telegram.telegrambots.meta.generics.TelegramClient
 import ru.devmark.openai.service.OpenAiService
 import ru.devmark.openai.util.createMessage
+
+private val logger = KotlinLogging.logger {}
 
 @Component
 class TelegramBot(
@@ -43,5 +45,4 @@ class TelegramBot(
         }
     }
 
-    private companion object : KLogging()
 }


### PR DESCRIPTION
## Summary
- replace deprecated `io.github.microutils:kotlin-logging` with `io.github.oshai:kotlin-logging-jvm`
- adopt new `KotlinLogging.logger` API for Telegram bot logger
- extract kotlin-logging version into a dedicated variable

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a43fa9e214832ebb369541f9bd7a72